### PR TITLE
RestCatalogApplication fails to start because of duplicated ControllerLinkBuilderFactory 

### DIFF
--- a/40-restful-sos/sos-rest-catalog/src/main/java/example/sos/rest/catalog/RestCatalogApplication.java
+++ b/40-restful-sos/sos-rest-catalog/src/main/java/example/sos/rest/catalog/RestCatalogApplication.java
@@ -15,16 +15,14 @@
  */
 package example.sos.rest.catalog;
 
-import example.sos.rest.events.EnablePersistentEvents;
-
 import java.math.BigDecimal;
 
-import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.hateoas.mvc.ControllerLinkBuilderFactory;
+
+import example.sos.rest.events.EnablePersistentEvents;
 
 /**
  * @author Oliver Gierke
@@ -35,11 +33,6 @@ public class RestCatalogApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(RestCatalogApplication.class, args);
-	}
-
-	@Bean(autowire = Autowire.BY_TYPE)
-	ControllerLinkBuilderFactory foo() {
-		return new ControllerLinkBuilderFactory();
 	}
 
 	@Bean


### PR DESCRIPTION
RestCatalogApplication fails to start because of a duplicated ControllerLinkBuilderFactory bean definition. 
```
Description:

Parameter 1 of constructor in example.sos.rest.events.api.EventController required a single bean, but 2 were found:
	- foo: defined by method 'foo' in example.sos.rest.catalog.RestCatalogApplication
	- controllerLinkBuilderFactoryBean: defined by method 'controllerLinkBuilderFactoryBean' in class path resource [org/springframework/hateoas/config/EntityLinksConfiguration.class]


Action:

Consider marking one of the beans as @Primary, updating the consumer to accept multiple beans, or using @Qualifier to identify the bean that should be consumed
```

I fixed this by removing the bean definition "foo" in example.sos.rest.catalog.RestCatalogApplication.