### PR TITLE
Catalog events cannot be accessed by order module

### DIFF
--- a/40-restful-sos/sos-rest-orders/src/main/java/example/sos/rest/orders/ProductInfo.java
+++ b/40-restful-sos/sos-rest-orders/src/main/java/example/sos/rest/orders/ProductInfo.java
@@ -36,6 +36,7 @@ import javax.persistence.Id;
  */
 @Data
 @Entity
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductInfo {
 

--- a/40-restful-sos/sos-rest-orders/src/main/java/example/sos/rest/orders/integration/IntegrationConfiguration.java
+++ b/40-restful-sos/sos-rest-orders/src/main/java/example/sos/rest/orders/integration/IntegrationConfiguration.java
@@ -39,7 +39,7 @@ class IntegrationConfiguration {
 	@Bean
 	RemoteResource productResource() {
 
-		ServiceInstance service = new DefaultServiceInstance("catalog", "localhost", 7071, false);
+		ServiceInstance service = new DefaultServiceInstance("catalog", "localhost", 7070, false);
 
 		return new DiscoveredResource(() -> service, traverson -> traverson.follow("events"));
 	}


### PR DESCRIPTION
The orders module can not access the catalog events because thewrong port is declared. 

After fixing this, Hibernate complained about the non-existent default constructor for example.sos.rest.orders.ProductInfo. I fixed that as well.